### PR TITLE
Add null support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: objective-c
+xcode_project: msgpack-objc.xcodeproj
+xcode_scheme: Tests
+xcode_destination: platform=iOS Simulator,OS=12.2,name=iPhone 8

--- a/Tests/MessagePackTests.m
+++ b/Tests/MessagePackTests.m
@@ -167,4 +167,14 @@
     }
 }
 
+- (void)testNull {
+    // minimal example, array with a single null
+    NSData *data = [[NSData alloc] initWithBase64EncodedString: @"kcA=" options: 0];
+    NSObject *unpacked = [MessagePack unpackData: data];
+    XCTAssertNotNil(unpacked);
+    XCTAssertTrue([unpacked isKindOfClass: [NSArray class]]);
+    XCTAssertEqual(1, [((NSArray *) unpacked) count]);
+    XCTAssertTrue([[((NSArray *) unpacked) objectAtIndex: 0] isKindOfClass: [NSNull class]]);
+}
+
 @end

--- a/msgpack-objc/MessagePack.m
+++ b/msgpack-objc/MessagePack.m
@@ -101,6 +101,8 @@ void packObject(id object, msgpack_packer *packer)
         NSData *data = (NSData *)object;
         msgpack_pack_bin(packer, data.length);
         msgpack_pack_bin_body(packer, data.bytes, data.length);
+    } else if ([object isKindOfClass: [NSNull class]]) {
+        msgpack_pack_nil(packer);
     } else {
         // Try to find a registered extension that supports unpacking of this object
         __block BOOL extensionFound;
@@ -180,7 +182,7 @@ id objectForMessagePackObject(msgpack_object object)
 {
     switch (object.type) {
         case MSGPACK_OBJECT_NIL:
-            return nil;
+            return [NSNull null];
 
         case MSGPACK_OBJECT_BOOLEAN:
             return @(object.via.boolean);


### PR DESCRIPTION
As-is, null support is simply broken in this library; the minimal test
case is the msgpacked value `[null]`, since this will attempt to create
an NSArray containing a nil value, which isn't allowed. Use NSNull to
represent nulls, and encode NSNull properly.

* msgpack-objc/MessagePack.m (packObject): encode NSNull.
  (objectForMessagePackObject): return NSNull instance for
  MSGPACK_OBJECT_NIL, not `nil`.
* Tests/MessagePackTests.m (testNull): new test.